### PR TITLE
feat(docker): Add multiarch support for AMD64, ARM and ARM64

### DIFF
--- a/.build/Build.Docker.cs
+++ b/.build/Build.Docker.cs
@@ -14,6 +14,8 @@ partial class Build : NukeBuild
 
     private string DockerImageTag => $"{DockerImage}:{DockerTag}";
 
+    private string[] DockerImagePlatforms => ["linux/amd64", "linux/arm", "linux/arm64"];
+
     Target BuildImage => _ => _
         .DependsOn(Test)
         .DependsOn(Format)
@@ -22,6 +24,7 @@ partial class Build : NukeBuild
                 .SetPath(".")
                 .SetFile("Dockerfile")
                 .SetTag(this.DockerImageTag)
+                .SetPlatform(string.Join(",", this.DockerImagePlatforms))
                 .AddCacheFrom("type=gha")
                 .AddCacheTo("type=gha,mode=max")
                 .AddLabel("org.opencontainers.image.source=https://github.com/maxnatamo/fetcharr")


### PR DESCRIPTION
Allows multiple different architectures to run Fetcharr - i.e. Raspberry Pis and M-series Macs.

However, I don't currently have access to any way of (efficiently) test whether these images function as they should.